### PR TITLE
Fix waterfall on request failure

### DIFF
--- a/install_files/js/check.js
+++ b/install_files/js/check.js
@@ -43,9 +43,14 @@ Installer.Pages.systemCheck.init = function() {
                         }
                     }, 500)
                 }).fail(function(data){
-                    item.removeClass('load').addClass('fail')
-                    if (data.responseText) console.log('Failure reason: ' + data.responseText)
-                    deferred.reject('ajaxFailure')
+                    setTimeout(function() {
+                        success = false
+                        failCodes.push(requirement.code)
+                        if (requirement.reason) failReasons.push(requirement.reason)
+                        if (data.responseText) console.log('Failure reason: ' + data.responseText)
+                        item.removeClass('load').addClass('fail')
+                        deferred.resolve()
+                    }, 500)
                 })
 
             return deferred;


### PR DESCRIPTION
When during the requirements check a request fails (as in a non-200
response), the waterfall stalls (this will happen when calling home
without cURL during the 'liveConnection' check, as curl_init() cannot be
found). This will fix this issue, plus the setTimeout() for keeping it
flowing. :)
