### PR TITLE
Add install log to gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+*.log


### PR DESCRIPTION
Currently, the install log is included in the git status list.  Log should be ignored so that sensitive logging details will not be committed on accident.
