### PR TITLE
Added optional port fields to database configuration forms.

### DIFF
--- a/install_files/partials/config/mysql.htm
+++ b/install_files/partials/config/mysql.htm
@@ -12,6 +12,19 @@
 </div>
 
 <div class="form-group">
+    <label for="dbHost" class="control-label col-sm-4">MySQL Port</label>
+    <div class="col-sm-8">
+        <input
+            id="dbPort"
+            name="db_port"
+            class="form-control"
+            placeholder="3306"
+            />
+        <span class="help-block">(Optional) Specify a non-default port for the database connection.</span>
+    </div>
+</div>
+
+<div class="form-group">
     <label for="dbName" class="control-label col-sm-4">Database Name</label>
     <div class="col-sm-8">
         <input

--- a/install_files/partials/config/pgsql.htm
+++ b/install_files/partials/config/pgsql.htm
@@ -12,6 +12,19 @@
 </div>
 
 <div class="form-group">
+    <label for="dbHost" class="control-label col-sm-4">Postgres Port</label>
+    <div class="col-sm-8">
+        <input
+            id="dbPort"
+            name="db_port"
+            class="form-control"
+            placeholder="5432"
+            />
+        <span class="help-block">(Optional) Specify a non-default port for the database connection.</span>
+    </div>
+</div>
+
+<div class="form-group">
     <label for="dbName" class="control-label col-sm-4">Database Name</label>
     <div class="col-sm-8">
         <input

--- a/install_files/partials/config/sqlsrv.htm
+++ b/install_files/partials/config/sqlsrv.htm
@@ -12,6 +12,19 @@
 </div>
 
 <div class="form-group">
+    <label for="dbHost" class="control-label col-sm-4">SQL Port</label>
+    <div class="col-sm-8">
+        <input
+            id="dbPort"
+            name="db_port"
+            class="form-control"
+            placeholder="1433"
+            />
+        <span class="help-block">(Optional) Specify a non-default port for the database connection.</span>
+    </div>
+</div>
+
+<div class="form-group">
     <label for="dbName" class="control-label col-sm-4">Database Name</label>
     <div class="col-sm-8">
         <input

--- a/install_files/php/Installer.php
+++ b/install_files/php/Installer.php
@@ -128,6 +128,7 @@ class Installer
             'name' => $this->post('db_name'),
             'user' => $this->post('db_user'),
             'pass' => $this->post('db_pass'),
+            'port' => $this->post('db_port'),
         ));
 
         extract($config);


### PR DESCRIPTION
As per #36, adds a `db_port` input for the user to specify a non-default port for the various database configurations. 

I just threw together an initial implementation. I wasn't sure about a couple things, so I figured I'd throw them up here for consideration: 
- Using `input[type=number]` - Not sure what the target compatibility is or what the issues would possibly be with using this. I can't imagine people using modern web frameworks and systems using anything too old to support this. Some style changes would be necessary to make those stupid increment/decrement buttons look nice... in my opinion, anyways.
- Not showing these fields by default for cleanliness? I considered having them hidden and having something the user clicks to reveal the field just to keep the form's simplicity by default. 
- Removing the `db_port` field altogether and allow the `host:port` notation in the `db_host` field and informing the user of this option in the help text beneath the field. 
