### PR TITLE
ISSUE-42 fix by supplying default port for pgsql

### DIFF
--- a/install_files/php/Installer.php
+++ b/install_files/php/Installer.php
@@ -456,7 +456,7 @@ class Installer
             case 'pgsql':
                 $result = array(
                     'connections.pgsql.host'     => $host,
-                    'connections.pgsql.port'     => $port,
+                    'connections.pgsql.port'     => empty($port) ? 5432 : $port,
                     'connections.pgsql.database' => $name,
                     'connections.pgsql.username' => $user,
                     'connections.pgsql.password' => $pass,


### PR DESCRIPTION
Leaving the port configuration key out of the default october database config (https://github.com/octobercms/october/blob/master/app/config/database.php) file could also solve the issue.
