### PR TITLE
Fix sqlite file permissions

### DIFF
--- a/install_files/php/Installer.php
+++ b/install_files/php/Installer.php
@@ -843,7 +843,7 @@ class Installer
 
         $directory = dirname($filename);
         if (!is_dir($directory))
-            mkdir($directory, 0666, true);
+            mkdir($directory, 0777, true);
 
         new SQLite3($filename);
     }


### PR DESCRIPTION
During installation with sqlite set as the DBMS I was getting the error 'Unable to open database file.'. It looks like the folder was being created with incorrect permissions. I've changed 0666 to 0777 to be in line with all other mkdir() calls.