### PR TITLE
Installation fails if password less than 4 chars

### DIFF
--- a/install_files/php/Installer.php
+++ b/install_files/php/Installer.php
@@ -200,6 +200,12 @@ class Installer
         if (!strlen($this->post('admin_password')))
             throw new InstallerException('Please specify password', 'admin_password');
 
+        if (strlen($this->post('admin_password')) < 4)
+            throw new InstallerException('Please specify password length more than 4 characters', 'admin_password');
+
+        if (strlen($this->post('admin_password')) > 64)
+            throw new InstallerException('Please specify password length less than 64 characters', 'admin_password');
+
         if (!strlen($this->post('admin_confirm_password')))
             throw new InstallerException('Please confirm chosen password', 'admin_confirm_password');
 


### PR DESCRIPTION
This happen because of password rules on this file
https://github.com/octobercms/october/blob/master/modules/backend/models/User.php#L26-L27

So, we should warn the user before installation progress fails.