### PR TITLE
Added support for PDO sql libary

### DIFF
--- a/install_files/php/Installer.php
+++ b/install_files/php/Installer.php
@@ -154,8 +154,10 @@ class Installer
                 if (in_array('dblib', $availableDrivers))
                     $dsn = 'dblib:host='.$host.$_port.';dbname='.$name;
                 else {
-                    $_name = ($name != '') ? ';Database='.$name : '';
-                    $dsn = 'dblib:host='.$host.$_port.$_name;
+					/*
+					 * dlib is obsolete, try PDO driver instead
+					 */
+					$dsn = 'sqlsrv:Server='.$host.(empty($port) ? '':','.$_port).';Database='.$name;
                 }
             break;
         }
@@ -173,6 +175,9 @@ class Installer
             $fetch = $db->query("select name from sqlite_master where type='table'", PDO::FETCH_NUM);
         elseif ($type == 'pgsql')
             $fetch = $db->query("select table_name from information_schema.tables where table_schema = 'public'", PDO::FETCH_NUM);
+		elseif ($type === 'sqlsrv') {
+            $fetch = $db->query("SELECT [TABLE_NAME] FROM INFORMATION_SCHEMA.TABLES", PDO::FETCH_NUM);
+        }
         else
             $fetch = $db->query('show tables', PDO::FETCH_NUM);
 


### PR DESCRIPTION
DLib is obsolete, like stonage obsolete.
I added support for PDO SQL when people use the php sqlserver libraries from Microsoft.
This way when people select SQL server it will actually work without having to resort
to an ancient sql server or ancient libraries. This will at least make the installer work :-)