### PR TITLE
Add prefix field to database config page

### DIFF
--- a/install_files/partials/config/mysql.htm
+++ b/install_files/partials/config/mysql.htm
@@ -38,6 +38,19 @@
 </div>
 
 <div class="form-group">
+    <label for="dbPrefix" class="control-label col-sm-4">Table Prefix</label>
+    <div class="col-sm-8">
+        <input
+            id="dbPrefix"
+            name="db_prefix"
+            class="form-control"
+            value=""
+            />
+        <span class="help-block">Specify an optional prefix for the database tables.</span>
+    </div>
+</div>
+
+<div class="form-group">
     <label for="dbUser" class="control-label col-sm-4">MySQL Login</label>
     <div class="col-sm-8">
         <input

--- a/install_files/partials/config/pgsql.htm
+++ b/install_files/partials/config/pgsql.htm
@@ -38,6 +38,19 @@
 </div>
 
 <div class="form-group">
+    <label for="dbPrefix" class="control-label col-sm-4">Table Prefix</label>
+    <div class="col-sm-8">
+        <input
+            id="dbPrefix"
+            name="db_prefix"
+            class="form-control"
+            value=""
+            />
+        <span class="help-block">Specify an optional prefix for the database tables.</span>
+    </div>
+</div>
+
+<div class="form-group">
     <label for="dbUser" class="control-label col-sm-4">Postgres Login</label>
     <div class="col-sm-8">
         <input

--- a/install_files/partials/config/sqlite.htm
+++ b/install_files/partials/config/sqlite.htm
@@ -10,3 +10,16 @@
         <span class="help-block">Specify a relative or absolute path to the SQLite database file. Path is relative to the application root directory.</span>
     </div>
 </div>
+
+<div class="form-group">
+    <label for="dbPrefix" class="control-label col-sm-4">Table Prefix</label>
+    <div class="col-sm-8">
+        <input
+            id="dbPrefix"
+            name="db_prefix"
+            class="form-control"
+            value=""
+            />
+        <span class="help-block">Specify an optional prefix for the database tables.</span>
+    </div>
+</div>

--- a/install_files/partials/config/sqlsrv.htm
+++ b/install_files/partials/config/sqlsrv.htm
@@ -38,6 +38,19 @@
 </div>
 
 <div class="form-group">
+    <label for="dbPrefix" class="control-label col-sm-4">Table Prefix</label>
+    <div class="col-sm-8">
+        <input
+            id="dbPrefix"
+            name="db_prefix"
+            class="form-control"
+            value=""
+            />
+        <span class="help-block">Specify an optional prefix for the database tables.</span>
+    </div>
+</div>
+
+<div class="form-group">
     <label for="dbUser" class="control-label col-sm-4">SQL Login</label>
     <div class="col-sm-8">
         <input

--- a/install_files/php/Installer.php
+++ b/install_files/php/Installer.php
@@ -446,6 +446,7 @@ class Installer
             case 'sqlite':
                 $result = array(
                     'connections.sqlite.database' => $name,
+                    'connections.sqlite.prefix'   => $prefix,
                 );
                 break;
 

--- a/install_files/php/Installer.php
+++ b/install_files/php/Installer.php
@@ -107,29 +107,18 @@ class Installer
 
     protected function onValidateDatabase()
     {
-        if ($this->post('db_type') != 'sqlite' && !strlen($this->post('db_host')))
+        $type = $this->post('db_type');
+        $host = $this->post('db_host');
+        $name = $this->post('db_name');
+        $user = $this->post('db_user');
+        $pass = $this->post('db_pass');
+        $port = $this->post('db_port');
+
+        if ($type != 'sqlite' && !strlen($host))
             throw new InstallerException('Please specify a database host', 'db_host');
 
-        if (!strlen($this->post('db_name')))
+        if (!strlen($name))
             throw new InstallerException('Please specify the database name', 'db_name');
-
-        $config = array_merge(array(
-            'type' => null,
-            'host' => null,
-            'name' => null,
-            'port' => null,
-            'user' => null,
-            'pass' => null,
-        ), array(
-            'type' => $this->post('db_type'),
-            'host' => $this->post('db_host'),
-            'name' => $this->post('db_name'),
-            'user' => $this->post('db_user'),
-            'pass' => $this->post('db_pass'),
-            'port' => $this->post('db_port'),
-        ));
-
-        extract($config);
 
         switch ($type) {
             case 'mysql':
@@ -433,25 +422,13 @@ class Installer
 
     private function getDatabaseConfigValues()
     {
-        $config = array_merge(array(
-            'type' => null,
-            'host' => null,
-            'name' => null,
-            'port' => null,
-            'user' => null,
-            'pass' => null,
-            'prefix' => null,
-        ), array(
-            'type' => $this->post('db_type'),
-            'host' => $this->post('db_host', ''),
-            'name' => $this->post('db_name', ''),
-            'port' => $this->post('db_port', ''),
-            'user' => $this->post('db_user', ''),
-            'pass' => $this->post('db_pass', ''),
-            'prefix' => $this->post('db_prefix', ''),
-        ));
-
-        extract($config);
+        $type = $this->post('db_type');
+        $host = $this->post('db_host', '');
+        $name = $this->post('db_name', '');
+        $port = $this->post('db_port', '');
+        $user = $this->post('db_user', '');
+        $pass = $this->post('db_pass', '');
+        $prefix = $this->post('db_prefix', '');
 
         switch ($type) {
             default:


### PR DESCRIPTION
All the handling was in place for a table prefix, but there was no input for it in the form. This commit adds the field to each of the provider forms -- and adds the variable to the php side for sqlite as well while we're at it.