### PR TITLE
Changing the minimum PHP version to 5.5.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The wizard installation is a recommended way to install October. It is simpler t
 
 October CMS has a few system requirements:
 
-* PHP 5.4 or higher
+* PHP 5.5.9 or higher
 * PDO PHP Extension
 * cURL PHP Extension
 * MCrypt PHP Extension


### PR DESCRIPTION
Following the install process, I guess the requirements should match in the `README` file
![ee935cf7adc71d03c909bfded14d9817](https://cloud.githubusercontent.com/assets/1972717/15552789/0f299048-228a-11e6-9bd6-4dd5859792fa.png)
