### PR TITLE
Add table prefix form group option to database selection.

### DIFF
--- a/install_files/partials/config/database.htm
+++ b/install_files/partials/config/database.htm
@@ -18,4 +18,17 @@
     </div>
 </div>
 
+<div class="form-group">
+    <label for="dbPrefix" class="control-label col-sm-4">Table Prefix</label>
+    <div class="col-sm-8">
+        <input
+            id="dbPrefix"
+            name="db_prefix"
+            class="form-control"
+            value=""
+            />
+        <span class="help-block">Please specify the prefix for tables.</span>
+    </div>
+</div>
+
 <div id="configFormDatabase"></div>


### PR DESCRIPTION
The ability to set a table prefix for the initial tables seems to be missing from the installer. This is useful to allow different October CMS installations to use a single database instance.