### PR TITLE
Add mod_rewrite check for CGI environments

### DIFF
--- a/install_files/php/Installer.php
+++ b/install_files/php/Installer.php
@@ -100,7 +100,7 @@ class Installer
                 $result = class_exists('ZipArchive');
                 break;
             case 'mod_rewrite':
-                $result = (strpos($_SERVER['SERVER_SOFTWARE'], 'Apache') === false) || array_key_exists('HTTP_MOD_REWRITE', $_SERVER);
+                $result = (strpos($_SERVER['SERVER_SOFTWARE'], 'Apache') === false) || array_key_exists('HTTP_MOD_REWRITE', $_SERVER) || array_key_exists('REDIRECT_HTTP_MOD_REWRITE', $_SERVER);
                 break;
         }
 


### PR DESCRIPTION
'HTTP_MOD_REWRITE' key is renamed to 'REDIRECT_HTTP_MOD_REWRITE' in CGI/FastCGI environments.