### PR TITLE
Fix data.status comparator

### DIFF
--- a/install_files/js/progress.js
+++ b/install_files/js/progress.js
@@ -97,7 +97,7 @@ Installer.Pages.installProgress.execDefaultStep = function(step, options) {
 
     $.sendRequest('onInstallStep', postData, { loadingIndicator: false })
         .fail(function(data){
-            if (data.status = 504) {
+            if (data.status == 504) {
                 deferred.reject("The operation timed out. Please increase the server's timeout and try again.<br/><br/>\
                     Relevant documentation for <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://httpd.apache.org/docs/2.4/mod/core.html#timeout\">Apache</a>,\
                     <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_read_timeout\">Nginx</a>.");


### PR DESCRIPTION
Setting `data.status = 504` returns the custom server timeout error message on every failure. Issue #91