### PR TITLE
Improved php version check to fix some issues

### DIFF
--- a/install_files/php/Installer.php
+++ b/install_files/php/Installer.php
@@ -76,7 +76,7 @@ class Installer
                 $result = is_writable(PATH_INSTALL) && is_writable($this->logFile);
                 break;
             case 'phpVersion':
-                $result = PHP_VERSION_ID >= 70000;
+                $result = PHP_VERSION_ID >= OCTOBER_MINIMUM_PHP_VERSION_ID;
                 break;
             case 'pdoLibrary':
                 $result = defined('PDO::ATTR_DRIVER_NAME');

--- a/install_files/php/Installer.php
+++ b/install_files/php/Installer.php
@@ -76,7 +76,7 @@ class Installer
                 $result = is_writable(PATH_INSTALL) && is_writable($this->logFile);
                 break;
             case 'phpVersion':
-                $result = version_compare(PHP_VERSION , "7.0", ">=");
+                $result = PHP_VERSION_ID >= 70000;
                 break;
             case 'pdoLibrary':
                 $result = defined('PDO::ATTR_DRIVER_NAME');

--- a/install_files/php/boot.php
+++ b/install_files/php/boot.php
@@ -2,6 +2,16 @@
 
 define('OCTOBER_MINIMUM_PHP_VERSION_ID', 70000);
 
+/**
+ * PHP_VERSION_ID is available as of PHP 5.2.7, if our 
+ * version is lower than that, then emulate it
+ */
+if (!defined('PHP_VERSION_ID')) {
+    $version = explode('.', PHP_VERSION);
+
+    define('PHP_VERSION_ID', ($version[0] * 10000 + $version[1] * 100 + $version[2]));
+}
+
 /*
  * Check PHP version
  */

--- a/install_files/php/boot.php
+++ b/install_files/php/boot.php
@@ -3,7 +3,7 @@
 /*
  * Check PHP version
  */
-if (version_compare(PHP_VERSION, '7.0', '<')) exit('You need at least PHP 7.0 to install October CMS.');
+if (PHP_VERSION_ID < 70000) exit('You need at least PHP 7.0 to install October CMS.');
 
 /*
  * Check for JSON extension

--- a/install_files/php/boot.php
+++ b/install_files/php/boot.php
@@ -1,9 +1,11 @@
 <?php
 
+define('OCTOBER_MINIMUM_PHP_VERSION_ID', 70000);
+
 /*
  * Check PHP version
  */
-if (PHP_VERSION_ID < 70000) exit('You need at least PHP 7.0 to install October CMS.');
+if (PHP_VERSION_ID < OCTOBER_MINIMUM_PHP_VERSION_ID) exit('You need at least PHP 7.0 to install October CMS.');
 
 /*
  * Check for JSON extension


### PR DESCRIPTION
On my computer (Windows and PHP 7.2.3 on XAMPP) the installation failed because of `PHP version 7.0 or greater required`.

I fixed this by changing `version_compare(PHP_VERSION , "7.0", ">=")` to `PHP_VERSION_ID >= 70000`, which is also recommended by PHPStorm IDE.