### PR TITLE
fixed installation on php 7.4

### DIFF
--- a/install_files/php/boot.php
+++ b/install_files/php/boot.php
@@ -69,7 +69,7 @@ function installerShutdown()
 {
     global $installer;
     $error = error_get_last();
-    if ($error['type'] == 1) {
+    if ($error && $error['type'] == 1) {
         header('HTTP/1.1 500 Internal Server Error');
         $errorMsg = htmlspecialchars_decode(strip_tags($error['message']));
         echo $errorMsg;


### PR DESCRIPTION
There is currently a problem with installing october CMS on php 7.4 this line of code throws an exception since $error is null and youre trying to access null as an array.

if you check the $error variable first, the exception is not thrown anymore