### PR TITLE
Flush cache after writing config

### DIFF
--- a/install_files/php/Installer.php
+++ b/install_files/php/Installer.php
@@ -1,7 +1,5 @@
 <?php
 
-use Illuminate\Support\Facades\Artisan;
-
 class Installer
 {
     /**
@@ -433,8 +431,8 @@ class Installer
         $this->rewriter->toFile($this->configDirectory . '/database.php', $this->getDatabaseConfigValues());
 
         // Force cache flush
-        Artisan::call('cache:clear');
-        Artisan::call('config:clear');
+        \Illuminate\Support\Facades\Artisan::call('cache:clear');
+        \Illuminate\Support\Facades\Artisan::call('config:clear');
         if (function_exists('opcache_reset')) {
             opcache_reset();
         }

--- a/install_files/php/Installer.php
+++ b/install_files/php/Installer.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Facades\Artisan;
+
 class Installer
 {
     /**
@@ -429,6 +431,13 @@ class Installer
         ));
 
         $this->rewriter->toFile($this->configDirectory . '/database.php', $this->getDatabaseConfigValues());
+
+        // Force cache flush
+        Artisan::call('cache:clear');
+        Artisan::call('config:clear');
+        if (function_exists('opcache_reset')) {
+            opcache_reset();
+        }
     }
 
     protected function getDatabaseConfigValues()

--- a/install_files/php/Installer.php
+++ b/install_files/php/Installer.php
@@ -436,6 +436,9 @@ class Installer
         if (function_exists('opcache_reset')) {
             opcache_reset();
         }
+        if (function_exists('apc_clear_cache')) {
+            apc_clear_cache();
+        }
     }
 
     protected function getDatabaseConfigValues()

--- a/install_files/php/Installer.php
+++ b/install_files/php/Installer.php
@@ -431,8 +431,6 @@ class Installer
         $this->rewriter->toFile($this->configDirectory . '/database.php', $this->getDatabaseConfigValues());
 
         // Force cache flush
-        \Illuminate\Support\Facades\Artisan::call('cache:clear');
-        \Illuminate\Support\Facades\Artisan::call('config:clear');
         if (function_exists('opcache_reset')) {
             opcache_reset();
         }


### PR DESCRIPTION
Attempts to fix https://github.com/octobercms/october/issues/3411 by flushing any configuration caching and opcode caching to help ensure that the correct configuration data is read before creating an admin account.