### PR TITLE
Update default file permissions

### DIFF
--- a/install_files/partials/config/advanced.htm
+++ b/install_files/partials/config/advanced.htm
@@ -41,7 +41,7 @@
             id="advFileMask"
             name="file_mask"
             class="form-control"
-            value="777" />
+            value="644" />
     </div>
 </div>
 
@@ -52,6 +52,12 @@
             id="advFolderMask"
             name="folder_mask"
             class="form-control"
-            value="777" />
+            value="755" />
     </div>
 </div>
+
+<p class="help-block">
+    * If file permission issues occur, then use <strong>777</strong> and <strong>666</strong>.
+    Setting the file permissions to either <strong>777</strong> means that anyone can write and
+    execute anything in that folder, this is highly not recommend for shared hosting.
+</p>

--- a/install_files/partials/config/advanced.htm
+++ b/install_files/partials/config/advanced.htm
@@ -58,6 +58,6 @@
 
 <p class="help-block">
     * If file permission issues occur, then use <strong>777</strong> and <strong>666</strong>.
-    Setting the file permissions to either <strong>777</strong> means that anyone can write and
+    Setting the file permissions to <strong>777</strong> means that anyone can write and
     execute anything in that folder, this is highly not recommend for shared hosting.
 </p>

--- a/install_files/partials/config/advanced.htm
+++ b/install_files/partials/config/advanced.htm
@@ -59,5 +59,5 @@
 <p class="help-block">
     * If file permission issues occur, then use <strong>777</strong> and <strong>666</strong>.
     Setting the file permissions to <strong>777</strong> means that anyone can write and
-    execute anything in that folder, this is highly not recommend for shared hosting.
+    execute anything in that folder. This is <strong>not recommended</strong> for shared hosting.
 </p>

--- a/install_files/php/Installer.php
+++ b/install_files/php/Installer.php
@@ -424,8 +424,8 @@ class Installer
         $this->rewriter->toFile($this->configDirectory . '/cms.php', array(
             'activeTheme' => $activeTheme,
             'backendUri'  => $this->post('backend_uri', '/backend'),
-            'defaultMask.file' => $this->post('file_mask', '777'),
-            'defaultMask.folder' => $this->post('folder_mask', '777'),
+            'defaultMask.file' => $this->post('file_mask', '644'),
+            'defaultMask.folder' => $this->post('folder_mask', '755'),
         ));
 
         $this->rewriter->toFile($this->configDirectory . '/database.php', $this->getDatabaseConfigValues());


### PR DESCRIPTION
@LukeTowers @bennothommo 

I feel bad asking so many questions from you both in the last few days, I decided to write this pr, my way of saying thanks.

This pr relates to this github issue: https://github.com/octobercms/october/issues/4905

I've basically taken bennothommo comment here:

> I think it might be better to default it to 755 and 644 anyways, with a note saying that if permission issues occur, then use 777 and 666, but also explain the risks involved. That way, we're not pushing unsafe values by default.

Pretty good stuff, and I've written a rough info statement, which I want you guys to edit and update.

Here's some before and after screenshots anyway.

### Before

![image](https://user-images.githubusercontent.com/57409060/73112932-f28f7e80-3f08-11ea-9347-7b9245749682.png)

### After

![image](https://user-images.githubusercontent.com/57409060/73113089-bf99ba80-3f09-11ea-8c96-3829f05ddb85.png)

Please comment and tag me and I'll update the pr based on your actions.